### PR TITLE
feat: add sync builder for autolink

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "~14.14.5",
     "@typescript-eslint/eslint-plugin": "2.19.2",
     "@typescript-eslint/parser": "2.19.2",
+    "chalk": "^4.1.0",
     "dotenv": "6.2.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.0.0",

--- a/packages/react-native/builders.json
+++ b/packages/react-native/builders.json
@@ -25,6 +25,11 @@
       "implementation": "./src/builders/start/start.impl",
       "schema": "./src/builders/start/schema.json",
       "description": "Starts the dev server for JS bundle."
+    },
+    "sync-deps": {
+      "implementation": "./src/builders/sync-deps/sync-deps.impl",
+      "schema": "./src/builders/sync-deps/schema.json",
+      "description": "Syncs dependencies to package.json (required for autolinking)."
     }
   }
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,6 +33,7 @@
     "react-native": "^0.63.0"
   },
   "dependencies": {
+    "chalk": "^4.1.0",
     "@nrwl/jest": "*",
     "@nrwl/react": "*",
     "@angular-devkit/schematics": "10.1.7",

--- a/packages/react-native/src/builders/run-android/schema.json
+++ b/packages/react-native/src/builders/run-android/schema.json
@@ -33,6 +33,11 @@
       "type": "boolean",
       "description": "Run jetifier – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don't support AndroidX yet.",
       "default": true
+    },
+    "sync": {
+      "type": "boolean",
+      "description": "Syncs npm dependencies to package.json (for React Native autolink).",
+      "default": true
     }
   }
 }

--- a/packages/react-native/src/builders/run-ios/run-ios.impl.ts
+++ b/packages/react-native/src/builders/run-ios/run-ios.impl.ts
@@ -1,12 +1,17 @@
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
 import { JsonObject } from '@angular-devkit/core';
-import { from, Observable } from 'rxjs';
+import { from, Observable, of } from 'rxjs';
 import { map, switchMap, tap } from 'rxjs/operators';
 import { join } from 'path';
-import { getProjectRoot } from '../../utils/get-project-root';
 import { fork } from 'child_process';
-import { ensureNodeModulesSymlink } from '../../utils/ensure-node-modules-symlink';
 import { platform } from 'os';
+import { getProjectRoot } from '../../utils/get-project-root';
+import { ensureNodeModulesSymlink } from '../../utils/ensure-node-modules-symlink';
+import {
+  displayNewlyAddedDepsMessage,
+  syncDeps,
+} from '../sync-deps/sync-deps.impl';
+import { podInstall } from '../../utils/pod-install-task';
 
 export interface ReactNativeRunIOsOptions extends JsonObject {
   configuration: string;
@@ -14,6 +19,8 @@ export interface ReactNativeRunIOsOptions extends JsonObject {
   scheme: string;
   simulator: string;
   device: string;
+  install?: boolean;
+  sync?: boolean;
 }
 
 export interface ReactNativeRunIOsOutput {
@@ -31,6 +38,20 @@ function run(
   }
   return from(getProjectRoot(context)).pipe(
     tap((root) => ensureNodeModulesSymlink(context.workspaceRoot, root)),
+    tap(
+      (root) =>
+        options.sync &&
+        displayNewlyAddedDepsMessage(
+          context.target.project,
+          syncDeps(context.target.project, root),
+          context
+        )
+    ),
+    switchMap((root) =>
+      options.install
+        ? podInstall(join(root, 'ios')).pipe(map(() => root))
+        : of(root)
+    ),
     switchMap((root) =>
       from(runCliRunIOS(context.workspaceRoot, root, options))
     ),
@@ -62,9 +83,11 @@ function runCliRunIOS(workspaceRoot, projectRoot, options) {
   });
 }
 
+const nxOptions = ['sync', 'install', 'no-sync'];
+
 function createRunIOSOptions(options) {
   return Object.keys(options).reduce((acc, k) => {
-    if (options[k]) acc.push(`--${k}`, options[k]);
+    if (options[k] && !nxOptions.includes(k)) acc.push(`--${k}`, options[k]);
     return acc;
   }, []);
 }

--- a/packages/react-native/src/builders/run-ios/schema.json
+++ b/packages/react-native/src/builders/run-ios/schema.json
@@ -20,6 +20,15 @@
     "device": {
       "type": "string",
       "description": "Explicitly set device to use by name. The value is not required if you have a single device connected."
+    },
+    "install": {
+      "type": "boolean",
+      "description": "Runs 'pod install' for native modules before building iOS app."
+    },
+    "sync": {
+      "type": "boolean",
+      "description": "Syncs npm dependencies to package.json (for React Native autolink). Always true when --install is used.",
+      "default": true
     }
   }
 }

--- a/packages/react-native/src/builders/sync-deps/schema.json
+++ b/packages/react-native/src/builders/sync-deps/schema.json
@@ -1,0 +1,6 @@
+{
+  "title": "Sync Deps for React Native",
+  "description": "Updates package.json with project dependencies",
+  "type": "object",
+  "properties": {}
+}

--- a/packages/react-native/src/builders/sync-deps/sync-deps.impl.ts
+++ b/packages/react-native/src/builders/sync-deps/sync-deps.impl.ts
@@ -1,0 +1,86 @@
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { JsonObject } from '@angular-devkit/core';
+import { from, Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { getProjectRoot } from '../../utils/get-project-root';
+import { join } from 'path';
+import { findAllNpmDependencies } from '../../utils/find-all-npm-dependencies';
+import { createProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { readJsonFile } from '@nrwl/workspace';
+import { writeJsonFile } from '@nrwl/workspace/src/utils/fileutils';
+import * as chalk from 'chalk';
+
+export interface ReactNativeDevServerOptions extends JsonObject {
+  host: string;
+  port: number;
+  resetCache: boolean;
+}
+
+export interface ReactNativeggSyncDepsOutput {
+  success: boolean;
+}
+
+export function syncDeps(projectName: string, projectRoot: string): string[] {
+  const graph = createProjectGraph();
+  const npmDeps = findAllNpmDependencies(graph, projectName);
+  const packageJsonPath = join(projectRoot, 'package.json');
+  const packageJson = readJsonFile(packageJsonPath);
+  const newDeps = [];
+  let updated = false;
+
+  if (!packageJson.dependencies) {
+    packageJson.dependencies = {};
+    updated = true;
+  }
+
+  npmDeps.forEach((dep) => {
+    if (!packageJson.dependencies[dep]) {
+      packageJson.dependencies[dep] = '*';
+      newDeps.push(dep);
+      updated = true;
+    }
+  });
+
+  if (updated) {
+    writeJsonFile(packageJsonPath, packageJson);
+  }
+
+  return newDeps;
+}
+
+export function displayNewlyAddedDepsMessage(
+  projectName: string,
+  deps: string[],
+  context: BuilderContext
+) {
+  if (deps.length > 0) {
+    context.logger.info(`${chalk.bold.cyan(
+      'info'
+    )} Added entries to 'package.json' for '${projectName}' (for autolink):
+  ${deps.map((d) => chalk.bold.cyan(`"${d}": "*"`)).join('\n  ')}`);
+  } else {
+    context.logger.info(
+      `${chalk.bold.cyan(
+        'info'
+      )} Dependencies for '${projectName}' are up to date! No changes made.`
+    );
+  }
+}
+
+export default createBuilder<ReactNativeDevServerOptions>(run);
+
+function run(
+  options: ReactNativeDevServerOptions,
+  context: BuilderContext
+): Observable<ReactNativeggSyncDepsOutput> {
+  return from(getProjectRoot(context)).pipe(
+    tap((root) =>
+      displayNewlyAddedDepsMessage(
+        context.target.project,
+        syncDeps(context.target.project, root),
+        context
+      )
+    ),
+    map(() => ({ success: true }))
+  );
+}

--- a/packages/react-native/src/schematics/application/application.impl.ts
+++ b/packages/react-native/src/schematics/application/application.impl.ts
@@ -128,7 +128,7 @@ function addProject(options: NormalizedSchema): Rule {
       builder: '@nrwl/react-native:build-android',
       outputs: [
         `${options.appProjectRoot}/android/app/build/outputs/bundle`,
-        `${options.appProjectRoot}/android/app/build/outputs/apk`
+        `${options.appProjectRoot}/android/app/build/outputs/apk`,
       ],
       options: {},
     };
@@ -148,6 +148,11 @@ function addProject(options: NormalizedSchema): Rule {
       Linter.EsLint,
       [`${options.appProjectRoot}/**/*.{js,ts,tsx}`]
     );
+
+    architect['sync-deps'] = {
+      builder: '@nrwl/react-native:sync-deps',
+      options: {},
+    };
 
     json.projects[options.projectName] = {
       root: options.appProjectRoot,

--- a/packages/react-native/src/utils/find-all-npm-dependencies.spec.ts
+++ b/packages/react-native/src/utils/find-all-npm-dependencies.spec.ts
@@ -1,0 +1,93 @@
+import { findAllNpmDependencies } from './find-all-npm-dependencies';
+import { ProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+
+test('findAllNpmDependencies', () => {
+  const graph: ProjectGraph = {
+    nodes: {
+      myapp: {
+        type: 'app',
+        name: 'myapp',
+        data: { files: [] },
+      },
+      lib1: {
+        type: 'lib',
+        name: 'lib1',
+        data: { files: [] },
+      },
+      lib2: {
+        type: 'lib',
+        name: 'lib2',
+        data: { files: [] },
+      },
+      lib3: {
+        type: 'lib',
+        name: 'lib3',
+        data: { files: [] },
+      },
+      'npm:react-native-image-picker': {
+        type: 'npm',
+        name: 'npm:react-native-image-picker',
+        data: {
+          files: [],
+          packageName: 'react-native-image-picker',
+        },
+      },
+      'npm:react-native-dialog': {
+        type: 'npm',
+        name: 'npm:react-native-dialog',
+        data: {
+          files: [],
+          packageName: 'react-native-dialog',
+        },
+      },
+      'npm:react-native-snackbar': {
+        type: 'npm',
+        name: 'npm:react-native-snackbar',
+        data: {
+          files: [],
+          packageName: 'react-native-snackbar',
+        },
+      },
+      'npm:@nrwl/react-native': {
+
+        type: 'npm',
+        name: 'npm:@nrwl/react-native',
+        data: {
+          files: [],
+          packageName: '@nrwl/react-native',
+        },
+      }
+    },
+    dependencies: {
+      myapp: [
+        { type: 'static', source: 'myapp', target: 'lib1' },
+        { type: 'static', source: 'myapp', target: 'lib2' },
+        {
+          type: 'static',
+          source: 'myapp',
+          target: 'npm:react-native-image-picker',
+        },        {
+          type: 'static',
+          source: 'myapp',
+          target: 'npm:@nrwl/react-native',
+        },
+      ],
+      lib1: [
+        { type: 'static', source: 'lib1', target: 'lib2' },
+        { type: 'static', source: 'lib3', target: 'npm:react-native-snackbar' },
+      ],
+      lib2: [{ type: 'static', source: 'lib2', target: 'lib3' }],
+      lib3: [
+        { type: 'static', source: 'lib3', target: 'npm:react-native-dialog' },
+      ],
+    },
+  };
+
+  const result = findAllNpmDependencies(graph, 'myapp');
+
+  expect(result).toEqual([
+    'react-native-dialog',
+    'react-native-snackbar',
+    'react-native-image-picker',
+  ]);
+});

--- a/packages/react-native/src/utils/find-all-npm-dependencies.ts
+++ b/packages/react-native/src/utils/find-all-npm-dependencies.ts
@@ -1,0 +1,27 @@
+import { ProjectGraph } from '@nrwl/workspace/src/core/project-graph';
+import { BuilderContext } from '@angular-devkit/architect';
+import * as chalk from 'chalk';
+
+export function findAllNpmDependencies(
+  graph: ProjectGraph,
+  projectName: string,
+  list: string[] = [],
+  seen = new Set<string>()
+) {
+  // In case of bad circular dependencies
+  if (seen.has(projectName)) return list;
+  seen.add(projectName);
+
+  const node = graph.nodes[projectName];
+
+  // Don't want to include '@nrwl/react-native' because React Native
+  // autolink will warn that the package has no podspec file for iOS.
+  if (node.type === 'npm' && node.name !== 'npm:@nrwl/react-native')
+    list.push(node.data.packageName);
+
+  graph.dependencies[projectName]?.forEach((dep) =>
+    findAllNpmDependencies(graph, dep.target, list, seen)
+  );
+
+  return list;
+}


### PR DESCRIPTION
This PR adds the ability to sync the app's dependencies to `package.json`. It will walk the dependency graph so dependencies of libs are also picked up.

Usage:
```
nx sync-deps my-app

# Automatically syncs when running ios  or android
nx run-ios my-app
nx run-android my-app

# Can turn it off via --no-sync
nx run-ios my-app --no-sync
nx run-android my-app --no-sync

# Can also run with 'pod install' for ios
nx run-ios my-app --install
```