### PR TITLE
feat: add support for running native dev app with different bundler ports

### DIFF
--- a/packages/react-native/nx_post_install.rb
+++ b/packages/react-native/nx_post_install.rb
@@ -1,0 +1,15 @@
+def nx_post_install (installer)
+    Pod::UI.info("[Nx] Updating build settings to support custom port")
+    installer.pods_project.targets.each do |target|
+      if ['React', 'React-Core'].include?(target.name)
+        target.build_configurations.each do |build_configuration|
+          if build_configuration.name == 'Debug'
+            gcc_preprocessor_defs = build_configuration.build_settings['GCC_PREPROCESSOR_DEFINITIONS']
+            gcc_preprocessor_defs ||= %w($(inherited) COCOAPODS=1 DEBUG=1)
+            gcc_preprocessor_defs << 'RCT_METRO_PORT=${RCT_METRO_PORT}' unless gcc_preprocessor_defs.include?('RCT_METRO_PORT')
+            build_configuration.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = gcc_preprocessor_defs
+          end
+        end
+      end
+    end
+  end

--- a/packages/react-native/src/builders/run-android/run-android.impl.ts
+++ b/packages/react-native/src/builders/run-android/run-android.impl.ts
@@ -6,7 +6,10 @@ import { join } from 'path';
 import { getProjectRoot } from '../../utils/get-project-root';
 import { fork } from 'child_process';
 import { ensureNodeModulesSymlink } from '../../utils/ensure-node-modules-symlink';
-import { displayNewlyAddedDepsMessage, syncDeps } from '../sync-deps/sync-deps.impl';
+import {
+  displayNewlyAddedDepsMessage,
+  syncDeps,
+} from '../sync-deps/sync-deps.impl';
 
 export interface ReactNativeRunAndroidOptions extends JsonObject {
   configuration: string;

--- a/packages/react-native/src/builders/run-ios/schema.json
+++ b/packages/react-native/src/builders/run-ios/schema.json
@@ -29,6 +29,11 @@
       "type": "boolean",
       "description": "Syncs npm dependencies to package.json (for React Native autolink). Always true when --install is used.",
       "default": true
+    },
+    "port": {
+      "type": "number",
+      "description": "The port where the JS bundler is listening on.",
+      "default": 8081
     }
   }
 }

--- a/packages/react-native/src/schematics/application/files/app/ios/Podfile.template
+++ b/packages/react-native/src/schematics/application/files/app/ios/Podfile.template
@@ -1,5 +1,6 @@
-require_relative '../../../node_modules/@react-native-community/cli-platform-ios/native_modules'
-require_relative '../../../node_modules/react-native/scripts/react_native_pods'
+require_relative '<%= offsetFromRoot %>../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '<%= offsetFromRoot %>../node_modules/react-native/scripts/react_native_pods'
+require_relative '<%= offsetFromRoot %>../node_modules/@nrwl/react-native/nx_post_install'
 
 platform :ios, '10.0'
 
@@ -8,12 +9,14 @@ target '<%= className %>' do
   puts config
   use_react_native!(:path => config[:reactNativePath])
 
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable these next few lines.
   use_flipper!
   post_install do |installer|
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable this next line.
     flipper_post_install(installer)
+
+    nx_post_install(installer)
   end
 end

--- a/packages/react-native/src/schematics/application/files/app/tsconfig.app.json.template
+++ b/packages/react-native/src/schematics/application/files/app/tsconfig.app.json.template
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
+    "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "types": ["node"]
   },
   "exclude": ["**/*.spec.ts", "**/*.spec.tsx"],

--- a/workspace.json
+++ b/workspace.json
@@ -41,6 +41,11 @@
               },
               {
                 "input": "./packages/react-native",
+                "glob": "*.rb",
+                "output": "."
+              },
+              {
+                "input": "./packages/react-native",
                 "glob": "collection.json",
                 "output": "."
               },


### PR DESCRIPTION
This PR adds the `--port` option to `run-ios` and `run-android`.

iOS: A new post install hook needs to be called in Podfile to update gcc preprocessor definitions.
Android: No modification needed, `--port` already works with the CLI.