### PR TITLE
feat: auto-run packager when starting android or ios app

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,14 +46,15 @@
     "dotenv": "6.2.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.0.0",
+    "ignore": "^5.0.4",
     "jest": "26.2.2",
     "metro-resolver": "0.58.0",
+    "node-fetch": "^2.6.1",
     "prettier": "2.1.2",
     "ts-jest": "26.1.4",
     "ts-node": "~7.0.0",
     "tslint": "~6.0.0",
-    "typescript": "4.0.5",
-    "ignore": "^5.0.4"
+    "typescript": "4.0.5"
   },
   "resolutions": {
     "rxjs": "6.6.0"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -38,6 +38,7 @@
     "@nrwl/react": "*",
     "@angular-devkit/schematics": "10.1.7",
     "metro-resolver": "0.58.0",
-    "ignore": "^5.0.4"
+    "ignore": "^5.0.4",
+    "node-fetch": "2.6.1"
   }
 }

--- a/packages/react-native/src/builders/run-android/schema.json
+++ b/packages/react-native/src/builders/run-android/schema.json
@@ -38,6 +38,16 @@
       "type": "boolean",
       "description": "Syncs npm dependencies to package.json (for React Native autolink).",
       "default": true
+    },
+    "port": {
+      "type": "number",
+      "description": "The port where the packager server is listening on.",
+      "default": 8081
+    },
+    "packager": {
+      "type": "boolean",
+      "description": "Starts the packager server",
+      "default": true
     }
   }
 }

--- a/packages/react-native/src/builders/run-ios/schema.json
+++ b/packages/react-native/src/builders/run-ios/schema.json
@@ -23,7 +23,8 @@
     },
     "install": {
       "type": "boolean",
-      "description": "Runs 'pod install' for native modules before building iOS app."
+      "description": "Runs 'pod install' for native modules before building iOS app.",
+      "default": true
     },
     "sync": {
       "type": "boolean",
@@ -32,8 +33,13 @@
     },
     "port": {
       "type": "number",
-      "description": "The port where the JS bundler is listening on.",
+      "description": "The port where the packager server is listening on.",
       "default": 8081
+    },
+    "packager": {
+      "type": "boolean",
+      "description": "Starts the packager server",
+      "default": true
     }
   }
 }

--- a/packages/react-native/src/builders/start/lib/is-packager-running.ts
+++ b/packages/react-native/src/builders/start/lib/is-packager-running.ts
@@ -1,0 +1,13 @@
+import * as fetch from 'node-fetch';
+
+export async function isPackagerRunning(
+  packagerPort: number
+): Promise<'running' | 'not_running' | 'unrecognized'> {
+  try {
+    const resp = await fetch(`http://localhost:${packagerPort}/status`);
+    const data = await resp.text();
+    return data === 'packager-status:running' ? 'running' : 'unrecognized';
+  } catch {
+    return 'not_running';
+  }
+}

--- a/packages/react-native/src/builders/start/lib/run-cli-start.ts
+++ b/packages/react-native/src/builders/start/lib/run-cli-start.ts
@@ -1,0 +1,48 @@
+import { ReactNativeStartOptions } from '../schema';
+import { concatMap, delay, map, retry, switchMap } from 'rxjs/operators';
+import { from, Observable, of } from 'rxjs';
+import { isPackagerRunning } from './is-packager-running';
+import { startAsync } from './start-async';
+
+/*
+ * Starts the JS bundler and checks for "running" status before notifying
+ * that packager has started.
+ */
+export function runCliStart(
+  workspaceRoot: string,
+  projectRoot: string,
+  options: ReactNativeStartOptions
+) {
+  return from(isPackagerRunning(options.port)).pipe(
+    concatMap((status) =>
+      status === 'running'
+        ? new Observable<void>((obs) => obs.next()) // don't complete the
+        : new Observable<void>((obs) => {
+            // If packager is already running on the port, then notify its status.
+            isPackagerRunning(options.port).then((status) => {
+              if (status === 'running') return;
+              return startAsync(workspaceRoot, projectRoot, options).catch(
+                (e) => {
+                  obs.error(e);
+                  obs.complete();
+                }
+              );
+            });
+            obs.next();
+          }).pipe(
+            // Check every second (up to 30 times) to see if the packager is running
+            concatMap(() =>
+              of(options.port).pipe(
+                switchMap((port) => from(isPackagerRunning(port))),
+                delay(1000),
+                map((status) => {
+                  if (status === 'running') return status;
+                  throw Error(`status: ${status}`);
+                }),
+                retry(30)
+              )
+            )
+          )
+    )
+  );
+}

--- a/packages/react-native/src/builders/start/lib/start-async.ts
+++ b/packages/react-native/src/builders/start/lib/start-async.ts
@@ -1,0 +1,38 @@
+import { ReactNativeStartOptions } from '../schema';
+import { fork } from 'child_process';
+import { join } from 'path';
+
+export function startAsync(
+  workspaceRoot: string,
+  projectRoot: string,
+  options: ReactNativeStartOptions
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const cp = fork(
+      join(workspaceRoot, './node_modules/react-native/cli.js'),
+      ['start', ...createStartOptions(options)],
+      { cwd: projectRoot }
+    );
+    cp.on('error', (err) => {
+      reject(err);
+    });
+    cp.on('exit', (code) => {
+      if (code === 0) {
+        resolve(code);
+      } else {
+        reject(code);
+      }
+    });
+  });
+}
+
+function createStartOptions(options) {
+  return Object.keys(options).reduce((acc, k) => {
+    if (k === 'resetCache') {
+      acc.push(`--reset-cache`);
+    } else {
+      acc.push(`--${k}`, options[k]);
+    }
+    return acc;
+  }, []);
+}

--- a/packages/react-native/src/builders/start/schema.d.ts
+++ b/packages/react-native/src/builders/start/schema.d.ts
@@ -1,0 +1,6 @@
+import { JsonObject } from '@angular-devkit/core';
+
+export interface ReactNativeStartOptions extends JsonObject {
+  port: number;
+  resetCache?: boolean;
+}

--- a/packages/react-native/src/builders/start/schema.json
+++ b/packages/react-native/src/builders/start/schema.json
@@ -1,13 +1,8 @@
 {
-  "title": "JS Bundle for React Native",
-  "description": "JS Bundle target options",
+  "title": "Packager Server for React Native",
+  "description": "Packager Server target options",
   "type": "object",
   "properties": {
-    "host": {
-      "type": "string",
-      "description": "The host to listen on.",
-      "default": "localhost"
-    },
     "port": {
       "type": "number",
       "description": "The port to listen on.",

--- a/packages/react-native/src/builders/start/start.impl.spec.ts
+++ b/packages/react-native/src/builders/start/start.impl.spec.ts
@@ -1,0 +1,81 @@
+import { from, of } from 'rxjs';
+import { MockBuilderContext } from '@nrwl/workspace/testing';
+
+import { getMockContext } from '../../utils/testing';
+import { startAsync } from './lib/start-async';
+import { isPackagerRunning } from './lib/is-packager-running';
+import { run } from './start.impl';
+
+jest.mock('./lib/start-async');
+jest.mock('./lib/is-packager-running');
+
+jest.mock('../../utils/ensure-node-modules-symlink', () => ({
+  ensureNodeModulesSymlink: () => {
+    // nothing
+  },
+}));
+
+jest.mock('../../utils/get-project-root', () => ({
+  getProjectRoot: () => of('/root/app'),
+}));
+
+describe('Start JS Bundler', () => {
+  let context: MockBuilderContext;
+  let mockStartAsync: jest.MockedFunction<typeof startAsync>;
+  let mockIsPackagerRunning: jest.MockedFunction<typeof isPackagerRunning>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    context = await getMockContext();
+    context.getProjectMetadata = jest
+      .fn()
+      .mockReturnValue({ sourceRoot: '/root/app/src' });
+
+    context.getTargetOptions = jest.fn().mockReturnValue({});
+
+    mockStartAsync = startAsync as jest.MockedFunction<typeof startAsync>;
+    mockIsPackagerRunning = isPackagerRunning as jest.MockedFunction<
+      typeof isPackagerRunning
+    >;
+  });
+
+  it('should notify with `baseHref` when packager is running', (done) => {
+    mockStartAsync.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* don't complete */
+        })
+    );
+
+    const statusCheckResultSequence = [
+      'not_running',
+      'not_running',
+      'not_running',
+      'unrecognized',
+      'unrecognized',
+      'running',
+    ].map((x) => Promise.resolve(x)) as ReturnType<typeof isPackagerRunning>[];
+    let callNum = 0;
+    mockIsPackagerRunning.mockImplementation(() => {
+      return statusCheckResultSequence[callNum++];
+    });
+
+    const sub = run({ host: 'localhost', port: 5000 }, context).subscribe(
+      (result) => {
+        expect(result).toEqual({
+          baseUrl: 'http://localhost:5000',
+          success: true,
+        });
+
+        expect(mockStartAsync).toHaveBeenCalledWith('/root', '/root/app', {
+          host: 'localhost',
+          port: 5000,
+        });
+
+        sub.unsubscribe();
+        done();
+      }
+    );
+  }, 10000);
+});

--- a/packages/react-native/src/builders/start/start.impl.ts
+++ b/packages/react-native/src/builders/start/start.impl.ts
@@ -1,78 +1,29 @@
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { JsonObject } from '@angular-devkit/core';
-import { from, Observable, throwError } from 'rxjs';
-import { catchError, switchMap, tap } from 'rxjs/operators';
+import { from, Observable, of } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { getProjectRoot } from '../../utils/get-project-root';
-import { platform } from 'os';
-import { fork } from 'child_process';
-import { join } from 'path';
 import { ensureNodeModulesSymlink } from '../../utils/ensure-node-modules-symlink';
+import { ReactNativeStartOptions } from './schema';
+import { runCliStart } from './lib/run-cli-start';
 
-export interface ReactNativeDevServerOptions extends JsonObject {
-  host: string;
-  port: number;
-  resetCache: boolean;
-}
-
-export interface ReactNativeDevServerBuildOutput {
-  baseUrl: string;
+export interface ReactNativeStartOutput {
+  baseUrl?: string;
   success: boolean;
 }
 
-export default createBuilder<ReactNativeDevServerOptions>(run);
+export default createBuilder<ReactNativeStartOptions>(run);
 
-function run(
-  options: ReactNativeDevServerOptions,
+export function run(
+  options: ReactNativeStartOptions,
   context: BuilderContext
-): Observable<ReactNativeDevServerBuildOutput> {
+): Observable<ReactNativeStartOutput> {
   return from(getProjectRoot(context)).pipe(
     tap((root) => ensureNodeModulesSymlink(context.workspaceRoot, root)),
-    switchMap((root) =>
-      from(runCliStart(context.workspaceRoot, root, options))
-    ),
-    catchError((err) => {
-      console.error(err);
-      return throwError(err);
-    }),
-    switchMap(
-      () =>
-        new Observable<ReactNativeDevServerBuildOutput>((obs) => {
-          obs.next({
-            baseUrl: `http://${options.host}:${options.port}`,
-            success: true
-          });
-        })
-    )
+    switchMap((root) => runCliStart(context.workspaceRoot, root, options)),
+    map(() => ({
+      baseUrl: `http://localhost:${options.port}`,
+      success: true,
+    })),
+    catchError(() => of({ success: false }))
   );
-}
-
-function runCliStart(workspaceRoot, projectRoot, options) {
-  return new Promise((resolve, reject) => {
-    const cp = fork(
-      join(workspaceRoot, './node_modules/react-native/cli.js'),
-      ['start', ...createStartOptions(options)],
-      { cwd: projectRoot }
-    );
-    cp.on('error', (err) => {
-      reject(err);
-    });
-    cp.on('exit', (code) => {
-      if (code === 0) {
-        resolve(code);
-      } else {
-        reject(code);
-      }
-    });
-  });
-}
-
-function createStartOptions(options) {
-  return Object.keys(options).reduce((acc, k) => {
-    if (k === 'resetCache') {
-      acc.push(`--reset-cache`);
-    } else {
-      acc.push(`--${k}`, options[k]);
-    }
-    return acc;
-  }, []);
 }

--- a/packages/react-native/src/utils/testing.ts
+++ b/packages/react-native/src/utils/testing.ts
@@ -1,8 +1,12 @@
+import { schema } from '@angular-devkit/core';
+import { Architect } from '@angular-devkit/architect';
+import { TestingArchitectHost } from '@angular-devkit/architect/testing';
 import { join } from 'path';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { Rule, Tree } from '@angular-devkit/schematics';
 import { names } from '@nrwl/workspace/src/utils/name-utils';
 import { updateWorkspace } from '@nrwl/workspace/src/utils/workspace';
+import { MockBuilderContext } from '@nrwl/workspace/testing';
 
 const testRunner = new SchematicTestRunner(
   '@nrwl/react-native',
@@ -36,4 +40,24 @@ export function createApp(tree: Tree, appName: string): Promise<Tree> {
     }),
     tree
   );
+}
+
+export async function getTestArchitect() {
+  const architectHost = new TestingArchitectHost('/root', '/root');
+  const registry = new schema.CoreSchemaRegistry();
+  registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+
+  const architect = new Architect(architectHost, registry);
+
+  await architectHost.addBuilderFromPackage(join(__dirname, '../..'));
+
+  return { architect, architectHost };
+}
+
+export async function getMockContext() {
+  const { architect, architectHost } = await getTestArchitect();
+
+  const context = new MockBuilderContext(architect, architectHost);
+  await context.addBuilderFromPackage(join(__dirname, '../..'));
+  return context;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8066,6 +8066,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"


### PR DESCRIPTION
This PR adds auto-start for the packager when either `run-ios` or `run-android` are used. You can turn it off with `--no-packager`.