### PR TITLE
resolve paths with wildcard

### DIFF
--- a/packages/react-native/plugins/with-nx-metro.ts
+++ b/packages/react-native/plugins/with-nx-metro.ts
@@ -1,22 +1,23 @@
 import { appRootPath } from '@nrwl/workspace/src/utils/app-root';
-import { resolveRequest } from './metro-resolver';
+import { getResolveRequest } from './metro-resolver';
 
 interface WithNxOptions {
   debug?: boolean;
+  extensions?: string[];
 }
 
 export function withNxMetro(config: any, opts: WithNxOptions = {}) {
+  const extensions = ['ts', 'tsx', 'js', 'jsx'];
   if (opts.debug) process.env.NX_REACT_NATIVE_DEBUG = 'true';
-
-  const resolver = config.resolver || {};
+  if (opts.extensions) extensions.push(...opts.extensions);
 
   // Set the root to workspace root so we can resolve modules and assets
   config.projectRoot = appRootPath;
 
   // Add support for paths specified by tsconfig
   config.resolver = {
-    ...resolver,
-    resolveRequest,
+    ...config.resolver,
+    resolveRequest: getResolveRequest(extensions),
   };
 
   return config;

--- a/packages/react-native/src/generators/application/files/app/metro.config.js
+++ b/packages/react-native/src/generators/application/files/app/metro.config.js
@@ -15,5 +15,7 @@ module.exports = withNxMetro(
     // Change this to true to see debugging info.
     // Useful if you have issues resolving modules
     debug: false,
+    // all the file extensions used for imports other than 'ts', 'tsx', 'js', 'jsx'
+    extensions: [],
   }
 );


### PR DESCRIPTION
- with paths with wildcard, when creating matcher, it needs to pass in all possible file extensions