### PR TITLE
fix the issue where js files are not resolve properly

### DIFF
--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -41,9 +41,10 @@ export function getResolveRequest(extensions: string[]) {
     if (match) {
       return {
         type: 'sourceFile',
-        filePath: match.endsWith(`.${matchExtension}`)
-          ? match
-          : `${match}.${matchExtension}`,
+        filePath:
+          !matchExtension || match.endsWith(`.${matchExtension}`)
+            ? match
+            : `${match}.${matchExtension}`,
       };
     } else {
       if (DEBUG) {

--- a/packages/react-native/plugins/with-nx-metro.ts
+++ b/packages/react-native/plugins/with-nx-metro.ts
@@ -7,7 +7,7 @@ interface WithNxOptions {
 }
 
 export function withNxMetro(config: any, opts: WithNxOptions = {}) {
-  const extensions = ['ts', 'tsx', 'js', 'jsx'];
+  const extensions = ['', 'ts', 'tsx', 'js', 'jsx'];
   if (opts.debug) process.env.NX_REACT_NATIVE_DEBUG = 'true';
   if (opts.extensions) extensions.push(...opts.extensions);
 


### PR DESCRIPTION
the issue is that when you call the function with an extension specified, if it is file, it returns right away. For example, `matcher('libs/lib2/src/index.js', undefined, undefined, ['.ts'])`, it will return `/Users/emilyxiong/Code/tmp/aztro-daily-horoscope/libs/lib2/src/index.js`. So add an empty extension to the extensions to be searched and if there is a match found on an empty extension, just return the match path.