### PR TITLE
Fix/add back no packager cli

### DIFF
--- a/packages/react-native/src/executors/start/start.impl.ts
+++ b/packages/react-native/src/executors/start/start.impl.ts
@@ -54,9 +54,9 @@ export async function runCliStart(
 ): Promise<void> {
   const result = await isPackagerRunning(options.port);
   if (result === 'running') {
-    throw new Error('JS server already running.');
+    logger.info('JS server already running.');
   } else if (result === 'unrecognized') {
-    throw new Error('JS server not recognized.');
+    logger.warn('JS server not recognized.');
   } else {
     // result === 'not_running'
     logger.info('Starting JS server...');


### PR DESCRIPTION
- add back the --no-packager option so react native cli does not launch the start, instead, in the same terminal, it will run `nx start ...`
- when react native cli launch start command, it will set the root directory as the parent of node_modules, which does not have metro.config file, so that is why i could not resolve the modules
fixes https://github.com/nrwl/nx-react-native/issues/72