### PR TITLE
fix resetCache option

### DIFF
--- a/packages/react-native/src/executors/start/start.impl.ts
+++ b/packages/react-native/src/executors/start/start.impl.ts
@@ -104,7 +104,9 @@ function startAsync(
 function createStartOptions(options) {
   return Object.keys(options).reduce((acc, k) => {
     if (k === 'resetCache') {
-      acc.push(`--reset-cache`);
+      if (options[k] === true) {
+        acc.push(`--reset-cache`);
+      }
     } else {
       acc.push(`--${k}`, options[k]);
     }


### PR DESCRIPTION
I noticed that the cache was always being reset when starting the application. The code was only checking for the presence of the `resetCache` option, but not for its value. Since that option has a default value (and even if the default value is `false`), the cache was always being reset.

This PR changes the logic to verify that the `resetCache` option has a value of `true`